### PR TITLE
Avoiding CI Output library

### DIFF
--- a/application/helpers/Json_output_helper.php
+++ b/application/helpers/Json_output_helper.php
@@ -4,9 +4,22 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
 	function json_output($statusHeader,$response)
 	{
-		$ci =& get_instance();
-		$ci->output->set_content_type('application/json');
-		$ci->output->set_status_header($statusHeader);
-		$ci->output->set_output(json_encode($response));
+	    if (isset($_SERVER['HTTP_ORIGIN'])) {
+	        header("Access-Control-Allow-Origin: {$_SERVER['HTTP_ORIGIN']}");
+	        header('Access-Control-Allow-Credentials: true');
+	        header('Access-Control-Max-Age: 86400');
+	    }
+	    if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+
+	        if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD']))
+	            header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
+
+	        if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']))
+	            header("Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}");
+
+	        exit(0);
+	    }
+	    http_response_code($statusHeader);
+	    echo json_encode($response);
 	}
 


### PR DESCRIPTION
This change fix the "Access-Control-Allow-Origin" error running the API between different servers, angular, Ionic etc.